### PR TITLE
upgrade deprecated GH actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,27 +1,37 @@
-name: build
+name: Publish Docker image
 
 on:
   push:
     branches: main
 
 jobs:
-  main:
+  push_to_registries:
+    name: Push Docker image to multiple registries
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: eoscostarica506/writer-middleware
-          tag_with_ref: true
-      - name: Push to GitHub Packages
-        uses: docker/build-push-action@v1
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v1
         with:
+          registry: docker.pkg.github.com
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: latamlink/writer-middleware/latest
-          tag_with_ref: true
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: eoscostarica506/writer-middleware:latest
+      - name: Build container image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: docker.pkg.github.com/${{ github.repository }}/writer-middleware:latest


### PR DESCRIPTION

Input 'repository' has been deprecated with message: `v2 is now available through docker/build-push-action@v2`